### PR TITLE
Catch invalid season names length

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28908,9 +28908,7 @@ function learnPlaylistName() {
         const year = process.env.YEAR
             ? parseInt(process.env.YEAR)
             : today.getFullYear();
-        const [marchEnd, juneEnd, septemberEnd, decemberEnd] = (0,lib_core.getInput)("seasonNames")
-            .split(",")
-            .map((s) => s.trim());
+        const [marchEnd, juneEnd, septemberEnd, decemberEnd] = validateSeasonNames();
         const seasons = {
             2: marchEnd,
             5: juneEnd,
@@ -28924,6 +28922,14 @@ function learnPlaylistName() {
     }
     (0,lib_core.exportVariable)("playlist", playlistName);
     return playlistName;
+}
+function validateSeasonNames() {
+    const seasonNames = (0,lib_core.getInput)("seasonNames")
+        .split(",")
+        .map((s) => s.trim());
+    if (seasonNames.length !== 4)
+        throw new Error(`There must be 4 seasons listed in \`seasonNames\` only found ${seasonNames.length} (\`${seasonNames}\`).`);
+    return seasonNames;
 }
 
 // EXTERNAL MODULE: ./node_modules/spotify-web-api-node/src/server.js

--- a/src/__test__/learn-playlist-name.test.ts
+++ b/src/__test__/learn-playlist-name.test.ts
@@ -73,6 +73,14 @@ describe("learnPlaylistName", () => {
     );
   });
 
+  test("Invalid seasonNames", () => {
+    process.env.MONTH = 5;
+    defaultInputs.seasonNames = "Summer";
+    expect(() => learnPlaylistName()).toThrow(
+      "There must be 4 seasons listed in `seasonNames` only found 1 (`Summer`)."
+    );
+  });
+
   test("Set workflow input `playlistName`", () => {
     process.env.MONTH = 1;
     Object.defineProperty(github, "context", {

--- a/src/learn-playlist-name.ts
+++ b/src/learn-playlist-name.ts
@@ -16,11 +16,8 @@ export default function learnPlaylistName(): string {
     const year = process.env.YEAR
       ? parseInt(process.env.YEAR)
       : today.getFullYear();
-    const [marchEnd, juneEnd, septemberEnd, decemberEnd] = getInput(
-      "seasonNames"
-    )
-      .split(",")
-      .map((s) => s.trim());
+    const [marchEnd, juneEnd, septemberEnd, decemberEnd] =
+      validateSeasonNames();
     const seasons = {
       2: marchEnd,
       5: juneEnd,
@@ -36,4 +33,15 @@ export default function learnPlaylistName(): string {
   }
   exportVariable("playlist", playlistName);
   return playlistName;
+}
+
+function validateSeasonNames() {
+  const seasonNames = getInput("seasonNames")
+    .split(",")
+    .map((s) => s.trim());
+  if (seasonNames.length !== 4)
+    throw new Error(
+      `There must be 4 seasons listed in \`seasonNames\` only found ${seasonNames.length} (\`${seasonNames}\`).`
+    );
+  return seasonNames;
 }


### PR DESCRIPTION
There must be 4 season names, this PR will add error handling if that's not the case.